### PR TITLE
Consistent server config management

### DIFF
--- a/bin/start-server.js
+++ b/bin/start-server.js
@@ -3,7 +3,7 @@
 const mongoose = require('mongoose')
 
 const server = require('../lib')
-const config = require('../config')
+const config = require('../config')()
 const database = require('../lib/database')
 
 const cliPort = process.argv.length > 2 && process.argv[2] || undefined

--- a/bin/start-server.js
+++ b/bin/start-server.js
@@ -1,19 +1,6 @@
 'use strict'
 
-const mongoose = require('mongoose')
+const config = require('../config')
+const app = require('../lib')(config())
 
-const server = require('../lib')
-const config = require('../config')()
-const database = require('../lib/database')
-
-const cliPort = process.argv.length > 2 && process.argv[2] || undefined
-const port = cliPort || config.port
-
-mongoose.Promise = global.Promise
-// const db = process.env.NODE_ENV === 'production' ? dbConfig.prod : dbConfig.dev
-// mongoose.connect(db)
-database.connect(config.database).then(() => {
-  server.listen(port, () => {
-    console.log(`Server started on Port: ${port} (${process.env.NODE_ENV} mode)`)
-  })
-})
+app.start()

--- a/bin/start-server.js
+++ b/bin/start-server.js
@@ -3,15 +3,17 @@
 const mongoose = require('mongoose')
 
 const server = require('../lib')
-const dbConfig = require('../../db-config')
+const config = require('../config')
+const database = require('../lib/database')
 
 const cliPort = process.argv.length > 2 && process.argv[2] || undefined
-const port = cliPort || process.env.PORT || 3000
+const port = cliPort || config.port
 
 mongoose.Promise = global.Promise
-const db = process.env.NODE_ENV === 'production' ? dbConfig.prod : dbConfig.dev
-mongoose.connect(db)
-
-server.listen(port, () => {
-  console.log(`Server started on Port: ${port}`)
+// const db = process.env.NODE_ENV === 'production' ? dbConfig.prod : dbConfig.dev
+// mongoose.connect(db)
+database.connect(config.database).then(() => {
+  server.listen(port, () => {
+    console.log(`Server started on Port: ${port} (${process.env.NODE_ENV} mode)`)
+  })
 })

--- a/config/default.js
+++ b/config/default.js
@@ -1,0 +1,19 @@
+const env = process.env
+const config = {
+  token: {
+    secret: env.ARROW_TOKEN_SECRET,
+    expiresIn: '24h'
+  },
+  database: {
+    host: 'localhost',
+    port: 27017,
+    dbName: 'arrow',
+    user: '',
+    password: ''
+  },
+  adminPassword: env.ARROW_ADMIN_PASSWORD,
+  port: env.ARROW_LISTEN_PORT || 3000
+}
+
+module.exports = config
+

--- a/config/development.js
+++ b/config/development.js
@@ -1,0 +1,12 @@
+const config = {
+  token: {
+    secret: 'secret'
+  },
+  database: {
+    host: '127.0.0.1',
+    port: 27017
+  },
+  adminPassword: 'admin_pw'
+}
+
+module.exports = config

--- a/config/index.js
+++ b/config/index.js
@@ -1,7 +1,7 @@
 const _ = require('lodash')
 const defaults = require('./default')
-const configEnv = process.env.NODE_ENV || 'development'
-const config = require(`./${configEnv}`)
 
-module.exports = _.merge({}, defaults, config)
-
+module.exports = () => {
+  const env = process.env.NODE_ENV || 'development'
+  return _.merge({}, defaults, require(`./${env}`))
+}

--- a/config/index.js
+++ b/config/index.js
@@ -1,10 +1,7 @@
-const config = {}
+const _ = require('lodash')
+const defaults = require('./default')
+const configEnv = process.env.NODE_ENV || 'development'
+const config = require(`./${configEnv}`)
 
-config.token = {
-  secret: '8cd96c8697d12daf4dfd135aec01fd63ee058ab4',
-  expiresInMinutes: 1440 // 24 hours
-}
+module.exports = _.merge({}, defaults, config)
 
-config.database = 'mongodb://127.0.0.1:27017/token'
-
-module.exports = config

--- a/config/production.js
+++ b/config/production.js
@@ -1,0 +1,16 @@
+const env = process.env
+const config = {
+  token: {
+    secret: env.ARROW_TOKEN_SECRET
+  },
+  database: {
+    host: env.ARROW_DATABASE_HOST,
+    port: env.ARROW_DATABASE_PORT,
+    user: env.ARROW_DATABASE_USER,
+    password: env.ARROW_DATABASE_PASSWORD
+  },
+  adminPassword: env.ARROW_ADMIN_PASSWORD,
+  port: env.ARROW_LISTEN_PORT
+}
+
+module.exports = config

--- a/config/production.js
+++ b/config/production.js
@@ -6,6 +6,7 @@ const config = {
   database: {
     host: env.ARROW_DATABASE_HOST,
     port: env.ARROW_DATABASE_PORT,
+    dbName: env.ARROW_DATABASE_DBNAME,
     user: env.ARROW_DATABASE_USER,
     password: env.ARROW_DATABASE_PASSWORD
   },

--- a/config/test.js
+++ b/config/test.js
@@ -1,0 +1,1 @@
+module.exports = require('./development')

--- a/config/test.js
+++ b/config/test.js
@@ -1,1 +1,13 @@
-module.exports = require('./development')
+const config = {
+  token: {
+    secret: 'secret',
+    expiresIn: '1h'
+  },
+  database: {
+    host: '127.0.0.1',
+    port: 27017
+  },
+  adminPassword: 'admin_pw'
+}
+
+module.exports = config

--- a/config/test.js
+++ b/config/test.js
@@ -5,7 +5,8 @@ const config = {
   },
   database: {
     host: '127.0.0.1',
-    port: 27017
+    port: 27017,
+    dbName: 'amos-test'
   },
   adminPassword: 'admin_pw'
 }

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1,0 +1,62 @@
+# REST API Reference
+This file documents the REST API input and output schemata for the route
+`/api/score`.
+
+## Input Schema
+All fields are optional unless specified as required.
+
+```json
+{
+    "file": {
+      "title": "(required) string ",
+      "type": "(required) string png/jpeg",
+      "created_at": "(required) unix timestamp",
+      "user": "(required) id string",
+      "description": "string that was sent with the upload",
+      "context": {
+        "chat": [ messages ]
+      }
+    },
+    "tasks": [
+      {
+        "title": "(required) string",
+        "created_at": "(required) unix timestamp",
+        "due_date": "unix timestamp",
+        "created_by": "(required) id string",
+        "last_updated_by": "id string",
+        "last_updated_at": "unix timestamp",
+        "assignees": ["userid1", "userid2", "..."],
+        "description": "string",
+        "location": "...",
+        "context": {
+          "chat": [ messages ]
+        }
+    },
+    "..."]
+}
+```
+
+### Possible Message Types
+We support all message formats that are specified in the Slack API.
+A detailed description of possible formats can be found in the
+[message events section](https://api.slack.com/events/message).
+
+
+## Output Schema
+Not yet finished.
+
+```json
+{
+  "tasks": [
+    {
+      "name": "string",
+      "score": 1.0,
+      "subscores": {
+        "plugin-a": 1.0,
+        "...": "..."
+      }
+    },
+    "..."
+  ]
+}
+```

--- a/docs/start-api.md
+++ b/docs/start-api.md
@@ -1,0 +1,37 @@
+# Starting the REST server
+
+## 1. Clone the repository and go into the project directory
+```
+$ git clone https://https://github.com/amos-ws16/amos-ws16-arrowjs-server.git arrowjs-server
+$ cd arrowjs-server
+```
+
+## 2. Setup the environment
+Configure the port the server will listen on, the administrator's password, and the secret used to sign tokens through the environment variables `ARROW_LISTEN_PORT`, `ARROW_ADMIN_PASSWORD`, `ARROW_TOKEN_SECRET` respectively. Also, setup the mongo database connection using the environment variables `ARROW_DATABASE_*`, e.g. in bash:
+```
+$ export ARROW_LISTEN_PORT=3000
+$ export ARROW_ADMIN_PASSWORD=foobar
+$ export ARROW_TOKEN_SECRET=verysecretthing
+$ export ARROW_DATABASE_HOST=localhost
+$ export ARROW_DATABASE_PORT=27017             # optional, default 27017
+$ export ARROW_DATABASE_USER=dbuser            # optional, default no user
+$ export ARROW_DATABASE_PASSWORD=dbpassword    # optional, default no password
+```
+
+## 3. Make sure the MongoDB is running
+The server needs a database connection to run, so the database configured in the previous section must be running before starting the REST server.
+
+## 3. Start the server
+```
+$ npm start
+```
+It is also possible to specify the port of the server on the command line which will override the environment variable `PORT`, for example to start on port 3000:
+```
+$ npm start -- 3000
+```
+
+The server is now listening for connections on port 3000 and the administrator can get an authentication token using the login `admin` and password provided through `ARROW_ADMIN_PASSWORD` by posting to `/api/auth`:
+```
+curl -X POST -H 'Content-Type: application/json' -d '{ "name": "admin", "password": "foobar" }' http://hostname:3000/api/auth
+```
+

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,8 +1,4 @@
 const Router = require('express-promise-router')
-const postApiScore = require('./post-api-score')
-const postApiAuth = require('./post-api-auth')
-const validateToken = require('./validate-token')
-// const validateAdmin = require('./validate-admin')
 const packageInfoServer = require('../package.json')
 const packageInfoEngine = require('../node_modules/arrow/package.json')
 
@@ -28,10 +24,10 @@ router.get('/welcome', (req, res) => {
 })
 
 // route to get a token
-router.post('/auth', postApiAuth)
+router.post('/auth', require('./post-api-auth'))
 // secure by token
-router.use(validateToken)
-router.post('/score', postApiScore)
+router.use(require('./validate-token'))
+router.post('/score', require('./post-api-score'))
 
 // // secure by admin rights (user management: list, add, remove)
 // // TODO: extract userId from request to get isAdmin from DB

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,5 +1,4 @@
 const User = require('./models/user')
-var config = require('../config')()
 
 /**
  * Return true if input user (inUser) credentials match the db record (dbUser).
@@ -15,9 +14,9 @@ function isInvalidUser (inUser, dbUser) {
  * @param username - the username to check
  * @param password - the password to authenticate username with
  */
-function authenticateUser (username, password) {
+function authenticateUser (username, password, adminPassword) {
   if (username === 'admin') {
-    return password === config.adminPassword
+    return password === adminPassword
       ? Promise.resolve(0) : Promise.resolve(null)
   }
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,5 +1,5 @@
 const User = require('./models/user')
-var config = require('../config')
+var config = require('../config')()
 
 /**
  * Return true if input user (inUser) credentials match the db record (dbUser).

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,4 +1,5 @@
 const User = require('./models/user')
+var config = require('../config')
 
 /**
  * Return true if input user (inUser) credentials match the db record (dbUser).
@@ -16,7 +17,7 @@ function isInvalidUser (inUser, dbUser) {
  */
 function authenticateUser (username, password) {
   if (username === 'admin') {
-    return password === process.env.ARROW_ADMIN_PASSWORD
+    return password === config.adminPassword
       ? Promise.resolve(0) : Promise.resolve(null)
   }
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -1,0 +1,47 @@
+const mongoose = require('mongoose')
+
+/**
+ * Return a URI string in the standard mongoose URI format given the provided
+ * configuration object, i.e. mongodb://username:password@host:port/database.
+ * @param config - an object with the fields host, dbName (required), user,
+ *                 password, and port (optional)
+ */
+function generateUri (config) {
+  const port = config.port || 27017
+  const userPart = ((user, password) => {
+    if (user && password) {
+      return `${user}:${password}@`
+    }
+    if (user) {
+      return `${user}@`
+    }
+    if (password) {
+      throw new Error('Database config: password without username')
+    }
+    return ''
+  })(config.user, config.password)
+
+  return `mongodb://${userPart}${config.host}:${port}/${config.dbName}`
+}
+
+/**
+ * Return a then-able promise that resolves when the connection was
+ * successfully established using the given config and rejects when there was
+ * an error while connecting.
+ * @param config - an object with the fields host, dbName (required), user,
+ *                 password, and port (optional)
+ */
+function connect (config) {
+  const uri = generateUri(config)
+  const connection = mongoose.createConnection(uri)
+  return new Promise((resolve, reject) => {
+    connection.once('error', (stream) => {
+      reject(stream)
+    })
+    connection.once('open', (stream) => {
+      resolve(stream)
+    })
+  })
+}
+
+module.exports = { connect, generateUri }

--- a/lib/database.js
+++ b/lib/database.js
@@ -33,15 +33,16 @@ function generateUri (config) {
  */
 function connect (config) {
   const uri = generateUri(config)
-  const connection = mongoose.createConnection(uri)
-  return new Promise((resolve, reject) => {
-    connection.once('error', (stream) => {
-      reject(stream)
-    })
-    connection.once('open', (stream) => {
-      resolve(stream)
-    })
-  })
+  return mongoose.connect(uri)
+  // const connection = mongoose.createConnection(uri)
+  // return new Promise((resolve, reject) => {
+  //   connection.once('error', (stream) => {
+  //     reject(stream)
+  //   })
+  //   connection.once('open', (stream) => {
+  //     resolve(stream)
+  //   })
+  // })
 }
 
 module.exports = { connect, generateUri }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+const http = require('http')
 const express = require('express')
 const bodyParser = require('body-parser')
 const mongoose = require('mongoose')
@@ -7,6 +8,13 @@ const database = require('../lib/database')
 const app = express()
 
 app.use(bodyParser.json())
+
+// Attach application config directly to each request.
+app.use((req, res, next) => {
+  req.config = req.app.locals.config
+  next()
+})
+
 app.use('/api', require('./api'))
 app.use(require('./error-handler').errorHandler)
 
@@ -15,8 +23,8 @@ module.exports = function initializeServer (config) {
   app.locals.config = config
 
   app.start = () => {
-    database.connect(config.database).then(() => {
-      app.listen(config.port, () => {
+    return database.connect(config.database).then(() => {
+      http.createServer(app).listen(config.port, () => {
         console.log(`Server started on Port: ${config.port} (${process.env.NODE_ENV} mode)`)
       })
     })

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,25 @@
-const errorHandler = require('./error-handler').errorHandler
 const express = require('express')
 const bodyParser = require('body-parser')
+const mongoose = require('mongoose')
+
+const database = require('../lib/database')
 
 const app = express()
 
 app.use(bodyParser.json())
 app.use('/api', require('./api'))
-app.use(errorHandler)
+app.use(require('./error-handler').errorHandler)
 
-module.exports = app
+module.exports = function initializeServer (config) {
+  mongoose.Promise = global.Promise
+  app.locals.config = config
+  app.start = () => {
+    database.connect(config.database).then(() => {
+      app.listen(config.port, () => {
+        console.log(`Server started on Port: ${config.port} (${process.env.NODE_ENV} mode)`)
+      })
+    })
+  }
+
+  return app
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ app.use(require('./error-handler').errorHandler)
 module.exports = function initializeServer (config) {
   mongoose.Promise = global.Promise
   app.locals.config = config
+
   app.start = () => {
     database.connect(config.database).then(() => {
       app.listen(config.port, () => {

--- a/lib/post-api-auth.js
+++ b/lib/post-api-auth.js
@@ -16,16 +16,20 @@ function postApiAuth (req, res) {
   const username = req.body.name
   const password = req.body.password
 
-  return auth.authenticateUser(username, password)
+  const config = req.config
+
+  return auth.authenticateUser(username, password, config.adminPassword)
     .then((userId) => {
       if (userId === null) {
         res.json({ success: false, message: 'Invalid credentials' })
         return undefined
       }
 
-      tokens.createToken(userId).then((tokenString) => {
-        res.json({ success: true, token: tokenString })
-      })
+      const tokenConfig = config.token
+      return tokens.createToken(userId, tokenConfig.secret, tokenConfig.expiresIn)
+        .then((tokenString) => {
+          res.json({ success: true, token: tokenString })
+        })
     })
 }
 

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -1,13 +1,12 @@
 const jwt = require('jsonwebtoken')
-const config = require('../config')()
 
 /**
  * Create a token for this application using the key given in the config.
  */
-function createToken (userId) {
+function createToken (userId, secret, expiresIn) {
   return new Promise((resolve, reject) => {
-    const options = { expiresIn: config.token.expiresIn }
-    jwt.sign({ data: userId }, config.token.secret, options, (err, token) => {
+    const options = { expiresIn: expiresIn }
+    jwt.sign({ data: userId }, secret, options, (err, token) => {
       if (err) {
         reject(err)
       } else {
@@ -20,9 +19,9 @@ function createToken (userId) {
 /**
  * Verify a token using the application's key given in the config.
  */
-function verifyToken (token) {
+function verifyToken (token, secret) {
   return new Promise((resolve, reject) => {
-    jwt.verify(token, config.token.secret, (err, decoded) => {
+    jwt.verify(token, secret, (err, decoded) => {
       if (err) {
         reject(err)
       } else {

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -1,5 +1,5 @@
 const jwt = require('jsonwebtoken')
-const config = require('../config')
+const config = require('../config')()
 
 /**
  * Create a token for this application using the key given in the config.

--- a/lib/validate-token.js
+++ b/lib/validate-token.js
@@ -10,7 +10,7 @@ function validateToken (req, res, next) {
     return Promise.resolve()
   }
 
-  return tokens.verifyToken(token)
+  return tokens.verifyToken(token, req.config.token.secret)
     .then((userId) => {
       req.userId = userId
       next()

--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
     "eslintfix": "eslint --fix **/*.js",
     "dev": "cross-env NODE_ENV=development node ./bin/start-server.js",
     "start": "cross-env NODE_ENV=production node ./bin/start-server.js",
-    "test": "eslint . && buster-test -g Unit",
-    "cover": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text buster-test",
+    "unit-tests": "cross-env NODE_ENV=test buster-test -g Unit",
+    "e2e-tests": "cross-env NODE_ENV=test buster-test -g E2E",
+    "all-tests": "cross-env NODE_ENV=test buster-test -g All",
+    "test": "eslint . && npm run unit-tests",
+    "cover": "nyc --reporter=lcov --reporter=text npm run all-tests",
     "coveralls": "npm run cover && nyc report --reporter=text-lcov | coveralls",
-    "scoretest": "node ./test/test-cases/test-cases-test.js && node ./test/test-cases/test-cases-run.js",
-    "e2e-test": "eslint . && buster-test -g E2E"
+    "scoretest": "node ./test/test-cases/test-cases-test.js && node ./test/test-cases/test-cases-run.js"
   },
   "dependencies": {
     "arrow": "amos-ws16/amos-ws16-arrowjs.git#dev",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint-plugin-standard": "^2.0.1",
     "istanbul": "^0.4.5",
     "nyc": "^8.4.0",
+    "proxyquire": "^1.7.11",
     "supertest": "^2.0.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "repository": "https://github.com/amos-ws16/amos-ws16-arrowjs-server",
   "devDependencies": {
     "buster": "^0.7.18",
-    "coveralls": "^2.11.14",
     "cli-table": "^0.3.1",
+    "coveralls": "^2.11.14",
     "cross-env": "^3.1.3",
     "eslint": "^3.9.0",
     "eslint-config-standard": "^6.2.1",
@@ -34,7 +34,6 @@
     "express-promise-router": "^1.1.1",
     "jsonwebtoken": "^7.2.1",
     "mongoose": "^4.7.7",
-    "verror": "^1.9.0",
-    "arrow": "amos-ws16/amos-ws16-arrowjs.git#dev"
+    "verror": "^1.9.0"
   }
 }

--- a/test/auth-test.js
+++ b/test/auth-test.js
@@ -2,7 +2,7 @@ const buster = require('buster')
 
 const auth = require('../lib/auth')
 const User = require('../lib/models/user')
-const config = require('../config')
+const config = require('../config')()
 
 buster.testCase('auth', {
   setUp: function () {

--- a/test/auth-test.js
+++ b/test/auth-test.js
@@ -2,7 +2,6 @@ const buster = require('buster')
 
 const auth = require('../lib/auth')
 const User = require('../lib/models/user')
-const config = require('../config')()
 
 buster.testCase('auth', {
   setUp: function () {
@@ -42,7 +41,7 @@ buster.testCase('auth', {
   },
 
   'should return userId = 0 when username is admin and password matches ARROW_ADMIN_PASSWORD environment variable': function () {
-    return auth.authenticateUser('admin', config.adminPassword).then((userId) => {
+    return auth.authenticateUser('admin', 'adminPassword', 'adminPassword').then((userId) => {
       buster.assert.same(userId, 0)
     })
   },

--- a/test/auth-test.js
+++ b/test/auth-test.js
@@ -2,6 +2,7 @@ const buster = require('buster')
 
 const auth = require('../lib/auth')
 const User = require('../lib/models/user')
+const config = require('../config')
 
 buster.testCase('auth', {
   setUp: function () {
@@ -41,7 +42,7 @@ buster.testCase('auth', {
   },
 
   'should return userId = 0 when username is admin and password matches ARROW_ADMIN_PASSWORD environment variable': function () {
-    return auth.authenticateUser('admin', 'admin password').then((userId) => {
+    return auth.authenticateUser('admin', config.adminPassword).then((userId) => {
       buster.assert.same(userId, 0)
     })
   },

--- a/test/buster.js
+++ b/test/buster.js
@@ -1,8 +1,12 @@
 var config = module.exports
 
-config['Unit Tests'] = {
+config['shared'] = {
   rootPath: '../',
-  environment: 'node', // or 'browser'
+  environment: 'node' // or 'browser'
+}
+
+config['Unit Tests'] = {
+  extends: 'shared',
   tests: [
     'test/**/*-test.js',
     '!test/test-cases/*.js',
@@ -11,9 +15,18 @@ config['Unit Tests'] = {
 }
 
 config['E2E Tests'] = {
-  rootPath: '../',
-  environment: 'node', // or 'browser'
+  extends: 'shared',
   tests: [
     'test/end-to-end/*.js'
   ]
 }
+
+config['All Tests'] = {
+  extends: 'shared',
+  tests: [
+    'test/**/*-test.js',
+    'test/**/*-e2e.js',
+    '!test/test-cases/*.js'
+  ]
+}
+

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -1,0 +1,36 @@
+const buster = require('buster')
+const proxyquire = require('proxyquire')
+
+// Stub out config files for /config/index.js.
+const config = proxyquire('../config', {
+  './default': { a: 'default', b: 'default' },
+  './development': { a: 'development' },
+  './test': { a: 'test', b: 'test' },
+  './production': { b: 'production' }
+})
+
+buster.testCase('Config loader', {
+  'should load development config when node_env was not set': function () {
+    process.env.NODE_ENV = ''
+
+    buster.assert.match(config(), { a: 'development', b: 'default' })
+  },
+
+  'should load test config when node_env was set to \'test\'': function () {
+    process.env.NODE_ENV = 'test'
+
+    buster.assert.match(config(), { a: 'test', b: 'test' })
+  },
+
+  'should load development config when node_env was set to \'development\'': function () {
+    process.env.NODE_ENV = 'development'
+
+    buster.assert.match(config(), { a: 'development', b: 'default' })
+  },
+
+  'should load production config when node_env was set to \'production\'': function () {
+    process.env.NODE_ENV = 'production'
+
+    buster.assert.match(config(), { a: 'default', b: 'production' })
+  }
+})

--- a/test/database-test.js
+++ b/test/database-test.js
@@ -1,0 +1,102 @@
+const buster = require('buster')
+
+const database = require('../lib/database')
+const mongoose = require('mongoose')
+
+buster.testCase('database', {
+  'generateUri': {
+    'should generate mongodb://host:27017/dbname when only hostname and dbname is provided': function () {
+      const dbconfig = {
+        host: 'myhost',
+        dbName: 'the_database'
+      }
+
+      const uri = database.generateUri(dbconfig)
+      buster.assert.equals(uri, 'mongodb://myhost:27017/the_database')
+    },
+
+    'should generate mongodb://host:27017/dbname when only hostname and dbname is provided 2': function () {
+      const dbconfig = {
+        host: 'my.other.host',
+        dbName: 'arrows_data'
+      }
+
+      const uri = database.generateUri(dbconfig)
+      buster.assert.equals(uri, 'mongodb://my.other.host:27017/arrows_data')
+    },
+
+    'should generate mongodb://host:port/dbname when port is provided': function () {
+      const dbconfig = {
+        host: 'my.other.host',
+        dbName: 'arrows_data',
+        port: 1234
+      }
+
+      const uri = database.generateUri(dbconfig)
+      buster.assert.equals(uri, 'mongodb://my.other.host:1234/arrows_data')
+    },
+
+    'should generate mongodb://user@host:port/dbname when user is provided': function () {
+      const dbconfig = {
+        host: 'my.other.host',
+        dbName: 'arrows_data',
+        user: 'mrsuper'
+      }
+
+      const uri = database.generateUri(dbconfig)
+      buster.assert.equals(uri, 'mongodb://mrsuper@my.other.host:27017/arrows_data')
+    },
+
+    'should generate mongodb://user:password@host:port/dbname when password is provided': function () {
+      const dbconfig = {
+        host: 'my.other.host',
+        dbName: 'arrows_data',
+        user: 'mrsuper',
+        password: 'super'
+      }
+
+      const uri = database.generateUri(dbconfig)
+      buster.assert.equals(uri, 'mongodb://mrsuper:super@my.other.host:27017/arrows_data')
+    },
+
+    'should throw if password is provided but no user': function () {
+      const dbconfig = {
+        host: 'my.other.host',
+        dbName: 'arrows_data',
+        password: 'super'
+      }
+
+      buster.assert.exception(() => database.generateUri(dbconfig))
+    }
+  },
+
+  'connect': {
+    setUp: function () {
+      this.onceStub = this.stub()
+      this.connectStub = this.stub(mongoose, 'createConnection').returns({ once: this.onceStub })
+    },
+
+    'should call mongoose with uri': function () {
+      this.onceStub.withArgs('open').yields()
+      return database.connect({ host: 'abc', dbName: 'd' }).then(() => {
+        buster.assert.calledWith(this.connectStub, 'mongodb://abc:27017/d')
+      })
+    },
+
+    'should wait for connection to open using once handler and return after it yields': function () {
+      this.onceStub.withArgs('open').yields('special thing')
+      return database.connect({ host: 'abc', dbName: 'd' }).then((something) => {
+        buster.assert.calledWith(this.onceStub, 'open')
+        buster.assert.equals(something, 'special thing')
+      })
+    },
+
+    'should reject if there is an error on the connection': function () {
+      this.onceStub.withArgs('error').yields('error thing')
+      return database.connect({ host: 'abc', dbName: 'd' }).catch((something) => {
+        buster.assert.calledWith(this.onceStub, 'error')
+        buster.assert.equals(something, 'error thing')
+      })
+    }
+  }
+})

--- a/test/database-test.js
+++ b/test/database-test.js
@@ -72,29 +72,26 @@ buster.testCase('database', {
 
   'connect': {
     setUp: function () {
-      this.onceStub = this.stub()
-      this.connectStub = this.stub(mongoose, 'createConnection').returns({ once: this.onceStub })
+      this.connectStub = this.stub(mongoose, 'connect')
     },
 
     'should call mongoose with uri': function () {
-      this.onceStub.withArgs('open').yields()
+      this.connectStub.returns(Promise.resolve())
       return database.connect({ host: 'abc', dbName: 'd' }).then(() => {
         buster.assert.calledWith(this.connectStub, 'mongodb://abc:27017/d')
       })
     },
 
-    'should wait for connection to open using once handler and return after it yields': function () {
-      this.onceStub.withArgs('open').yields('special thing')
+    'should wait for connection to open and return the same promise': function () {
+      this.connectStub.returns(Promise.resolve('special thing'))
       return database.connect({ host: 'abc', dbName: 'd' }).then((something) => {
-        buster.assert.calledWith(this.onceStub, 'open')
         buster.assert.equals(something, 'special thing')
       })
     },
 
     'should reject if there is an error on the connection': function () {
-      this.onceStub.withArgs('error').yields('error thing')
+      this.connectStub.returns(Promise.reject('error thing'))
       return database.connect({ host: 'abc', dbName: 'd' }).catch((something) => {
-        buster.assert.calledWith(this.onceStub, 'error')
         buster.assert.equals(something, 'error thing')
       })
     }

--- a/test/end-to-end/auth-e2e.js
+++ b/test/end-to-end/auth-e2e.js
@@ -2,8 +2,9 @@ const buster = require('buster')
 const request = require('supertest')
 const mongoose = require('mongoose')
 
-const testDb = require('../../../db-config').test
+const config = require('../../config')
 const app = require('../../lib')
+const generateDatabaseUri = require('../../lib/database').generateUri
 
 mongoose.Promise = global.Promise
 
@@ -18,7 +19,7 @@ buster.testCase('E2E: Authentication', {
       ]
     }
 
-    this.dbLink = mongoose.createConnection(testDb)
+    this.dbLink = mongoose.createConnection(generateDatabaseUri(config.database))
     this.dbLink.once('open', () => {
       done()
     })
@@ -31,11 +32,9 @@ buster.testCase('E2E: Authentication', {
   },
 
   'should respond with valid token when given correct username and password': function () {
-    process.env.ARROW_ADMIN_PASSWORD = '1234'
-
     return request(app)
       .post('/api/auth')
-      .send({ name: 'admin', password: '1234' })
+      .send({ name: 'admin', password: config.adminPassword })
       .expect('Content-Type', /json/)
       .expect(200)
       .then(res => {

--- a/test/end-to-end/auth-e2e.js
+++ b/test/end-to-end/auth-e2e.js
@@ -3,7 +3,7 @@ const request = require('supertest')
 const mongoose = require('mongoose')
 
 const config = require('../../config')()
-const app = require('../../lib')
+const app = require('../../lib')(config)
 const generateDatabaseUri = require('../../lib/database').generateUri
 
 mongoose.Promise = global.Promise

--- a/test/end-to-end/auth-e2e.js
+++ b/test/end-to-end/auth-e2e.js
@@ -2,7 +2,7 @@ const buster = require('buster')
 const request = require('supertest')
 const mongoose = require('mongoose')
 
-const config = require('../../config')
+const config = require('../../config')()
 const app = require('../../lib')
 const generateDatabaseUri = require('../../lib/database').generateUri
 

--- a/test/end-to-end/auth-e2e.js
+++ b/test/end-to-end/auth-e2e.js
@@ -5,8 +5,20 @@ const mongoose = require('mongoose')
 const makeConfig = require('../../config')
 const makeApp = require('../../lib')
 const generateDatabaseUri = require('../../lib/database').generateUri
+const User = require('../../lib/models/user')
 
 mongoose.Promise = global.Promise
+
+/** Provision the database with two users */
+function setUpUsers () {
+  return User.remove({})
+    .then(() => {
+      User.create([
+        { name: 'alice', password: 'alicepw', isAdmin: true },
+        { name: 'bob', password: 'bobpw', isAdmin: false }
+      ])
+    })
+}
 
 buster.testCase('E2E: Authentication', {
   setUp: function (done) {
@@ -24,16 +36,14 @@ buster.testCase('E2E: Authentication', {
 
     this.config = makeConfig()
 
-    this.dbLink = mongoose.createConnection(generateDatabaseUri(this.config.database))
-    this.dbLink.once('open', () => {
-      done()
-    })
+    mongoose.connect(generateDatabaseUri(this.config.database))
+      .then(() => {
+        return setUpUsers()
+      })
+      .then(() => done())
   },
   tearDown: function (done) {
-    this.dbLink.close()
-    this.dbLink.once('close', () => {
-      done()
-    })
+    mongoose.connection.close(done)
   },
 
   'should respond with valid token when given correct username and password': function () {
@@ -60,6 +70,23 @@ buster.testCase('E2E: Authentication', {
       })
       .then(res => {
         buster.assert.isTrue(res.body.success)
+      })
+  },
+
+  'should allow username and password saved in database': function () {
+    const app = makeApp(this.config)
+    return request(app)
+      .post('/api/auth')
+      .send({ name: 'alice', password: 'alicepw' })
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then(res => {
+        const body = res.body
+        buster.assert.isTrue(body.success)
+
+        const token = body.token
+        buster.assert.isString(token)
+        buster.assert.greater(token.length, 0)
       })
   },
 

--- a/test/end-to-end/score-e2e.js
+++ b/test/end-to-end/score-e2e.js
@@ -1,0 +1,34 @@
+const buster = require('buster')
+const request = require('supertest')
+const config = require('../../config')()
+const app = require('../../lib')(config)
+
+buster.testCase('POST /api/score', {
+  // TODO: needs to be adapted to new API
+  '//should pass data to score manager': (done) => {
+    let blob = {
+      file: { title: 'location.png' },
+      tasks: [
+        { title: 'location' },
+        { title: 'something_else' }
+      ]
+    }
+
+    request(app)
+      .post('/api/score')
+      .send(blob)
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .end(done((err, res) => {
+        buster.refute(err)
+
+        let expected = [
+          { score: 1.0, scores: { 'same-title': 1.0 } },
+          { score: 0.0, scores: { 'same-title': 0.0 } }
+        ]
+
+        buster.assert.match(res.body, expected)
+      }))
+  }
+})
+

--- a/test/end-to-end/welcome-e2e.js
+++ b/test/end-to-end/welcome-e2e.js
@@ -1,7 +1,7 @@
 const buster = require('buster')
 const request = require('supertest')
-const config = require('../config')()
-const app = require('../lib')(config)
+const config = require('../../config')()
+const app = require('../../lib')(config)
 
 buster.testCase('GET /api/welcome', {
   'should return a welcome message': (done) => {
@@ -45,31 +45,3 @@ buster.testCase('GET /api/welcome', {
   }
 })
 
-buster.testCase('POST /api/score', {
-  // TODO: needs to be adapted to new API
-  '//should pass data to score manager': (done) => {
-    let blob = {
-      file: { title: 'location.png' },
-      tasks: [
-        { title: 'location' },
-        { title: 'something_else' }
-      ]
-    }
-
-    request(app)
-      .post('/api/score')
-      .send(blob)
-      .expect('Content-Type', /json/)
-      .expect(200)
-      .end(done((err, res) => {
-        buster.refute(err)
-
-        let expected = [
-          { score: 1.0, scores: { 'same-title': 1.0 } },
-          { score: 0.0, scores: { 'same-title': 0.0 } }
-        ]
-
-        buster.assert.match(res.body, expected)
-      }))
-  }
-})

--- a/test/server-acceptance-test.js
+++ b/test/server-acceptance-test.js
@@ -1,6 +1,7 @@
 const buster = require('buster')
 const request = require('supertest')
-const app = require('../lib')
+const config = require('../config')()
+const app = require('../lib')(config)
 
 buster.testCase('GET /api/welcome', {
   'should return a welcome message': (done) => {

--- a/test/start-test.js
+++ b/test/start-test.js
@@ -1,0 +1,45 @@
+const buster = require('buster')
+const sinon = require('sinon')
+
+const makeApp = require('../lib')
+
+const http = require('http')
+const database = require('../lib/database')
+
+buster.testCase('app.start()', {
+  setUp: function () {
+    this.config = {
+      database: 'database config',
+      port: 1234
+    }
+    this.connect = this.stub(database, 'connect').returns(Promise.resolve())
+    this.listen = this.stub().yields()
+    this.stub(http, 'createServer').returns({ listen: this.listen })
+    this.log = this.stub(console, 'log')
+  },
+
+  'should connect to the database with credentials given in the config': function () {
+    const app = makeApp(this.config)
+    return app.start()
+      .then(() => {
+        buster.assert.calledWith(this.connect, 'database config')
+      })
+  },
+
+  'should listen on the port given in the config': function () {
+    const app = makeApp(this.config)
+    return app.start()
+      .then(() => {
+        buster.assert.calledWith(this.listen, 1234)
+      })
+  },
+
+  'should give a log message with mode and port': function () {
+    const app = makeApp(this.config)
+    return app.start()
+      .then(() => {
+        buster.assert.calledWith(this.log, sinon.match(/1234/))
+        buster.assert.calledWith(this.log, sinon.match(/test mode/))
+      })
+  }
+})

--- a/test/tokens-test.js
+++ b/test/tokens-test.js
@@ -1,7 +1,6 @@
 const buster = require('buster')
 
 const tokens = require('../lib/tokens')
-const config = require('../config')()
 const jwt = require('jsonwebtoken')
 
 buster.testCase('tokens', {
@@ -15,8 +14,8 @@ buster.testCase('tokens', {
     },
 
     'should call jwt sign to create token': function () {
-      return tokens.createToken(this.userId).then(() => {
-        buster.assert.calledWith(this.sign, { data: this.userId }, config.token.secret, { expiresIn: config.token.expiresIn })
+      return tokens.createToken(this.userId, 'secret', '1h').then(() => {
+        buster.assert.calledWith(this.sign, { data: this.userId }, 'secret', { expiresIn: '1h' })
       })
     },
 
@@ -42,8 +41,8 @@ buster.testCase('tokens', {
     },
 
     'should call jwt verify to validate the token': function () {
-      return tokens.verifyToken(this.tokenString).then(() => {
-        buster.assert.calledWith(this.verify, this.tokenString, config.token.secret)
+      return tokens.verifyToken(this.tokenString, 'secret').then(() => {
+        buster.assert.calledWith(this.verify, this.tokenString)
       })
     },
 

--- a/test/tokens-test.js
+++ b/test/tokens-test.js
@@ -1,7 +1,7 @@
 const buster = require('buster')
 
 const tokens = require('../lib/tokens')
-const config = require('../config')
+const config = require('../config')()
 const jwt = require('jsonwebtoken')
 
 buster.testCase('tokens', {

--- a/test/validate-token-test.js
+++ b/test/validate-token-test.js
@@ -5,14 +5,14 @@ const tokens = require('../lib/tokens')
 
 buster.testCase('validateToken', {
   setUp: function () {
+    this.req = { config: { token: { secret: 'secret' } }, body: {} }
     this.res = { send: this.stub(), json: this.stub(), status: this.stub() }
     this.res.status.returns(this.res)
     this.next = this.stub()
   },
 
   'should fail when no token was provided': function () {
-    const body = {}
-    return validateToken({ body }, this.res, this.next)
+    return validateToken(this.req, this.res, this.next)
       .then(() => {
         buster.assert.calledWith(this.res.json, sinon.match.has('success', false))
         buster.assert.calledWith(this.res.json, sinon.match.has('message'))
@@ -20,8 +20,7 @@ buster.testCase('validateToken', {
   },
 
   'should set response code to forbidden 403 when no token was provided': function () {
-    const body = {}
-    return validateToken({ body }, this.res, this.next)
+    return validateToken(this.req, this.res, this.next)
       .then(() => {
         buster.assert.calledWith(this.res.status, 403)
       })
@@ -30,20 +29,18 @@ buster.testCase('validateToken', {
   'should pass token to verifyToken if it was sent': function () {
     let verifyStub = this.stub(tokens, 'verifyToken').returns(Promise.resolve(null))
 
-    const body = { token: 'atoken' }
-    let req = { body }
-    return validateToken(req, this.res, this.next)
+    this.req.body = { token: 'atoken' }
+    return validateToken(this.req, this.res, this.next)
       .then(() => {
-        buster.assert.calledWith(verifyStub, 'atoken')
+        buster.assert.calledWith(verifyStub, 'atoken', 'secret')
       })
   },
 
   'should call next if token is verified successfully': function () {
     this.stub(tokens, 'verifyToken').returns(Promise.resolve(123))
 
-    const body = { token: 'atoken' }
-    let req = { body }
-    return validateToken(req, this.res, this.next)
+    this.req.body = { token: 'atoken' }
+    return validateToken(this.req, this.res, this.next)
       .then(() => {
         buster.assert.called(this.next)
       })
@@ -52,9 +49,8 @@ buster.testCase('validateToken', {
   'should return failure code when validation failed': function () {
     this.stub(tokens, 'verifyToken').returns(Promise.reject('error'))
 
-    const body = { token: 'atoken' }
-    let req = { body }
-    return validateToken(req, this.res, this.next)
+    this.req.body = { token: 'atoken' }
+    return validateToken(this.req, this.res, this.next)
       .then(() => {
         buster.assert.calledWith(this.res.json, sinon.match.has('success', false))
         buster.assert.calledWith(this.res.json, sinon.match.has('message'))
@@ -64,9 +60,8 @@ buster.testCase('validateToken', {
   'should not call next when validation failed': function () {
     this.stub(tokens, 'verifyToken').returns(Promise.reject('error'))
 
-    const body = { token: 'atoken' }
-    let req = { body }
-    return validateToken(req, this.res, this.next)
+    this.req.body = { token: 'atoken' }
+    return validateToken(this.req, this.res, this.next)
       .then(() => {
         buster.refute.called(this.next)
       })
@@ -75,9 +70,8 @@ buster.testCase('validateToken', {
   'should return error message when validation failed': function () {
     this.stub(tokens, 'verifyToken').returns(Promise.reject('error'))
 
-    const body = { token: 'atoken' }
-    let req = { body }
-    return validateToken(req, this.res, this.next)
+    this.req.body = { token: 'atoken' }
+    return validateToken(this.req, this.res, this.next)
       .then(() => {
         buster.assert.calledWith(this.res.json, sinon.match.has('message', sinon.match(/[iI]nvalid [tT]oken/)))
       })
@@ -86,11 +80,10 @@ buster.testCase('validateToken', {
   'should save decoded token in request object': function () {
     this.stub(tokens, 'verifyToken').returns(Promise.resolve(123))
 
-    const body = { token: 'atoken' }
-    let req = { body }
-    return validateToken(req, this.res, this.next)
+    this.req.body = { token: 'atoken' }
+    return validateToken(this.req, this.res, this.next)
       .then(() => {
-        buster.assert.equals(req.userId, 123)
+        buster.assert.equals(this.req.userId, 123)
       })
   }
 })


### PR DESCRIPTION
Konfiguration wird jetzt je nach Umgebung (`NODE_ENV = development/test/production`) ausgewählt. Für den Wert `production` die Werte werden standardmäßig durch Umgebungsvariablen gesetzt. Für `development` und `test` die Werte können in `config/development.js` und `config/test.js` direkt gesetzt werden. Ihr könnt das zu eurem lokalen Setup anpassen (bitte dann aber nicht mit committen).

Die Konfiguration wird außerdem jetzt in express an den Request angehängt, sodass in jedem Router `(req, res) => ` mit `req.config` auf die Konfiguration zugegriffen werden kann. 

Durch diese Änderungen können leicht neue Konfigurationsparameter in `config/default.js` konsistent hinzugefügt werden.

Kleinere weitere Änderungen:
 + `npm run unit-tests`, `npm run e2e-tests`, `npm run all-tests` (das normale `npm test` funktioniert natürlich trotzdem noch wie gehabt)
 + in `lib/auth.js` und `lib/token.js` werden die entsprechenden Parameter aus der Config als Funktionsparameter übergeben (keine globalen Variablen mehr -> leichter zu testen)
 + Die Logik des 'Starte den Server' wurde von `bin/start-server.js` nach `lib/index.js` geschoben und wird jetzt auch mit getesten (`bin/start-server.js` macht jetzt nur noch das Minimum um `config` mit `app` zu instanzieren und `app.start()` aufzurufen).