### PR TITLE
Reenable SSL tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,6 @@ function makeServer (app, useHttps) {
 module.exports = function initializeServer (config) {
   mongoose.Promise = global.Promise
   app.locals.config = config
-  // const useHttps = process.env.NODE_ENV === 'production'
 
   app.start = () => {
     return database.connect(config.database).then(() => {

--- a/test/post-api-score-test.js
+++ b/test/post-api-score-test.js
@@ -1,9 +1,7 @@
 const buster = require('buster')
-const VError = require('verror').VError
 const postApiScore = require('../lib/post-api-score')
 const scoreManager = require('arrow')
 const config = require('arrow/config/default')
-const InvalidInputError = require('arrow/lib/invalid-input-error')
 
 const sinon = require('sinon')
 const logging = require('../lib/logging.js')
@@ -47,38 +45,5 @@ buster.testCase('postApiScore', {
       buster.assert.calledWith(this.res.json, sinon.match.has('uid', '123'))
       done()
     })
-  },
-
-  '//should pass along error message on input error': function (done) {
-    this.fakeScoreManager.score.throws(new InvalidInputError('There was a problem'))
-    postApiScore(this.req, this.res, () => {
-      buster.assert.calledWith(this.res.json, sinon.match.has('success', false))
-      buster.assert.calledWith(this.res.json, sinon.match.has('error', 'There was a problem'))
-      buster.assert.calledWith(this.res.json, sinon.match.has('uid', '123'))
-      done()
-    })
-  },
-
-  '//should pass along error message on wrapped input error': function (done) {
-    this.fakeScoreManager.score.throws(
-      new VError(
-        new InvalidInputError('There was a specific problem'),
-        'There was a general problem'))
-    postApiScore(this.req, this.res, () => {
-      buster.assert.calledWith(this.res.json, sinon.match.has('success', false))
-      buster.assert.calledWith(this.res.json, sinon.match.has('error', 'There was a general problem: There was a specific problem'))
-      buster.assert.calledWith(this.res.json, sinon.match.has('uid', '123'))
-      done()
-    })
-  },
-
-  '//should signal an internal server error on error conditions other than input and rethrow exception': function (done) {
-    this.fakeScoreManager.score.throws(new Error('There was an internal problem'))
-    buster.assert.exception(() => postApiScore(this.req, this.res, () => {
-      buster.assert.calledWith(this.res.json, sinon.match.has('success', false))
-      buster.assert.calledWith(this.res.json, sinon.match.has('error', 'Internal Server Error'))
-      buster.assert.calledWith(this.res.json, sinon.match.has('uid', '123'))
-      done()
-    }))
   }
 })

--- a/test/start-test.js
+++ b/test/start-test.js
@@ -5,12 +5,13 @@ const makeApp = require('../lib')
 
 const http = require('http')
 const https = require('https')
-// const fs = require('fs')
+const fs = require('fs')
 const database = require('../lib/database')
 
 buster.testCase('app.start()', {
   setUp: function () {
     this.originalNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'test'
     this.config = {
       database: 'database config',
       port: 1234
@@ -48,10 +49,10 @@ buster.testCase('app.start()', {
         buster.assert.calledWith(this.log, sinon.match(/1234/))
         buster.assert.calledWith(this.log, sinon.match(/test mode/))
       })
-  }
+  },
 
-  /* 'should start in https mode when node_env is production': function () {
-    process.env.NODE_ENV = 'production'
+  'should start in https mode when useHttps is set in config': function () {
+    this.config.useHttps = true
     this.readFileSync = this.stub(fs, 'readFileSync')
     this.readFileSync.withArgs('cert/key.pem').returns('the key')
     this.readFileSync.withArgs('cert/cert.pem').returns('the cert')
@@ -61,5 +62,4 @@ buster.testCase('app.start()', {
         buster.assert.calledWith(this.https, { key: 'the key', cert: 'the cert' })
       })
   }
-  */
 })


### PR DESCRIPTION
Additionally, removed tests of postApiScore that are now obsolete. Error handling is now done and tested in errorHandler route.